### PR TITLE
Fix 'invalid_grant' error

### DIFF
--- a/lib/omniauth/strategies/microsoft_live.rb
+++ b/lib/omniauth/strategies/microsoft_live.rb
@@ -51,9 +51,14 @@ module OmniAuth
       protected
 
       def build_access_token
-        super.tap do |token|
+        original_build_access_token.tap do |token|
           handle_cookie(token)
         end
+      end
+
+      def original_build_access_token
+        verifier = request.params["code"]
+        client.auth_code.get_token(verifier, {:redirect_uri => options.callback_url}.merge(token_params.to_hash(:symbolize_keys => true)), deep_symbolize(options.auth_token_params))
       end
 
       def handle_cookie(access_token)


### PR DESCRIPTION
Plain `callback_url` was polluted with querystring parameters. Using instead `options.callback_url` gets around this issue.
